### PR TITLE
delete_file: fix for files not deleted on end of playlist

### DIFF
--- a/delete_file.lua
+++ b/delete_file.lua
@@ -29,14 +29,12 @@ function mark_delete()
    end
 end
 
-function delete(e)
-   if e.reason == "quit" then
-      for i, v in pairs(del_list) do
-         print("deleting: "..v)
-         os.remove(v)
-      end
+function delete()
+   for i, v in pairs(del_list) do
+      print("deleting: "..v)
+      os.remove(v)
    end
 end
 
 mp.add_key_binding("ctrl+DEL", "delete_file", mark_delete)
-mp.register_event("end-file", delete)
+mp.register_event("shutdown", delete)


### PR DESCRIPTION
Currently, the selected files are deleted only when mpv is
exited via the quit command. If, however, the quit reason is
eof of the last file in the playlist, delete_file would not
delete any files.

To fix this use the correct event, i.e. shutdown, instead of
end-file.

See:

https://github.com/mpv-player/mpv/blob/master/DOCS/man/lua.rst#list-of-events