### PR TITLE
fix set_property aid cannot be set to nil

### DIFF
--- a/speed-transition.lua
+++ b/speed-transition.lua
@@ -23,7 +23,7 @@ function restore_normalspeed()
    if mp.get_property_native("video-sync") == "desync" then
       mp.set_property("video-sync", "audio")
    end
-   if aid~=mp.get_property("aid") then mp.set_property("aid", aid) end
+   if (aid~=nil and aid~=mp.get_property("aid")) then mp.set_property("aid", aid) end
 end
 
 function check_should_speedup()


### PR DESCRIPTION
If you attempt to set_property("aid", nil) the script will throw an error.

This has been crashing on me a couple of times. I guess this problem becomes apparent on slower machines... 