### PR TITLE
leadin does not actually need to clamp upper limit

### DIFF
--- a/speed-transition.lua
+++ b/speed-transition.lua
@@ -1,6 +1,6 @@
 lookahead = 5
 speedup = 2.5
-leadin = 1 --range 0-2
+leadin = 1
 skipmode = false
 directskip = false
 ---------------
@@ -166,7 +166,7 @@ function change_speedup(v)
 end
 
 function change_leadin(v)
-   leadin = clamp(leadin + v, 0, 2)
+   leadin = clamp(leadin + v, 0, nil)
    mp.osd_message("leadin: "..leadin)
 end
 


### PR DESCRIPTION
While it becomes technically confusing to have very high leadins, the script actually handles it as would be desired. I think this was an arbitrary limit set for someone's usecase. I didn't see a reason attributed in https://github.com/zenyd/mpv-scripts/commit/a9b5c4eee632029c5a7c32d7616d80b908323d02