### PR TITLE
Provider Auth Configuration

### DIFF
--- a/subselect.py
+++ b/subselect.py
@@ -20,6 +20,7 @@ class subselect :
         self.best_button = Button(frame, text="Best", command=self.download_best_subtitle)
         self.best_button.grid(row=0, column=2, sticky=E+W)
         self.result_listbox = Listbox(self.root)
+        self.providers_auth = {'provider': {'username': 'user', 'password': 'pass'}}
 
     def show_subtitles(self, subtitles) :
         self.result_listbox.delete(0, END)
@@ -65,7 +66,7 @@ class subselect :
     def search(self) :
         try :
             self.video = self.get_video_from_title()
-            subtitles = list_subtitles([self.video], {Language(self.language)}, providers=None)
+            subtitles = list_subtitles([self.video], {Language(self.language)}, providers=None, provider_configs=self.providers_auth)
         except ValueError as exc :
             self.show_message("Error", str(exc))
         else :
@@ -74,7 +75,7 @@ class subselect :
     def download_best_subtitle(self) :
         try :
             self.video = self.get_video_from_title()
-            best_subtitles = download_best_subtitles([self.video], {Language(self.language)})
+            best_subtitles = download_best_subtitles([self.video], {Language(self.language)}, provider_configs=self.providers_auth)
         except ValueError as exc :
             self.show_message("Error", str(exc))
         else :
@@ -90,7 +91,7 @@ class subselect :
             self.show_message("Download failed", "Please select a subtitle")
         else :
             selected_subtitle = self.subtitles_in_list[i[0]]
-            download_subtitles([selected_subtitle])
+            download_subtitles([selected_subtitle], provider_configs=self.providers_auth)
             self.save_subtitle(self.video, True, selected_subtitle)
     
     def save_subtitle(self, video, change_filename, subtitle) :


### PR DESCRIPTION
- {'provider': {'username': 'user', 'password': 'pass'}}
- Here you can pass on auth config to various providers like opensubtitles and others.
ex.
{'opensubtitles': {'username': 'user', 'password': 'pass'}}
- Multiple providers can be passed as such, each separated by a comma [.]
{'provider1': {'username': 'user', 'password': 'pass'}, 'provider2': {'username': 'user', 'password': 'pass'}, 'provider3': {'username': 'user', 'password': 'pass'}}

This is to mainly bypass the errors where certain providers are skipped due to not being authorized. Like OpenSubtitles which made it compulsary to have user accounts to download via their api.