### PR TITLE
Portable Configuration

### DIFF
--- a/subselect/main.lua
+++ b/subselect/main.lua
@@ -5,6 +5,7 @@ options = {}
 options.down_dir = ""
 options.sub_language = "eng"
 options.subselect_path = utils.join_path(mp.get_script_directory(), "subselect.py")
+options.python = "python"
 
 if package.config:sub(1,1) == "/" then
    ops = "unix"
@@ -66,7 +67,7 @@ function get_python_binary()
    python_error = ""
    python_version = mp.command_native({
       name = "subprocess",
-      args = { "python", "--version"},
+      args = { options.python, "--version"},
       capture_stdout = true
    })
 
@@ -74,17 +75,17 @@ function get_python_binary()
       python_error = "python not found"
    else
       if python_version.stdout:find("3%.") ~= nil then
-         python = "python"
+         python = options.python
       else
          python_version = mp.command_native({
             name = "subprocess",
-            args = { "python3", "--version" }
+            args = { options.python.."3", "--version" }
          })
          
          if python_version.error_string ~= "" then
             python_error = "python3 not installed"
          else
-            python = "python3"
+            python = options.python.."3"
          end
       end
    end

--- a/subselect/main.lua
+++ b/subselect/main.lua
@@ -6,6 +6,7 @@ options.down_dir = ""
 options.sub_language = "eng"
 options.subselect_path = utils.join_path(mp.get_script_directory(), "subselect.py")
 options.python = "python"
+options.providers_auth = "{}"
 
 if package.config:sub(1,1) == "/" then
    ops = "unix"
@@ -101,7 +102,7 @@ function search_subs()
    if python ~= nil then
       ret = mp.command_native({
          name = "subprocess",
-         args = { python, options.subselect_path, video, options.down_dir, options.sub_language },
+         args = { python, options.subselect_path, video, options.down_dir, options.sub_language, options.providers_auth },
          capture_stdout = true
       })
    else

--- a/subselect/subselect.py
+++ b/subselect/subselect.py
@@ -3,6 +3,7 @@ from subliminal import *
 from babelfish import Language
 import sys, os
 import tkinter.messagebox
+import json
 
 class subselect :
 
@@ -20,7 +21,6 @@ class subselect :
         self.best_button = Button(frame, text="Best", command=self.download_best_subtitle)
         self.best_button.grid(row=0, column=2, sticky=E+W)
         self.result_listbox = Listbox(self.root)
-        self.providers_auth = {'provider': {'username': 'user', 'password': 'pass'}}
 
     def show_subtitles(self, subtitles) :
         self.result_listbox.delete(0, END)
@@ -66,7 +66,7 @@ class subselect :
     def search(self) :
         try :
             self.video = self.get_video_from_title()
-            subtitles = list_subtitles([self.video], {Language(self.language)}, providers=None, provider_configs=self.providers_auth)
+            subtitles = list_subtitles([self.video], {Language(self.language)}, providers=None, provider_configs=providers_auth)
         except ValueError as exc :
             self.show_message("Error", str(exc))
         else :
@@ -75,7 +75,7 @@ class subselect :
     def download_best_subtitle(self) :
         try :
             self.video = self.get_video_from_title()
-            best_subtitles = download_best_subtitles([self.video], {Language(self.language)}, provider_configs=self.providers_auth)
+            best_subtitles = download_best_subtitles([self.video], {Language(self.language)}, provider_configs=providers_auth)
         except ValueError as exc :
             self.show_message("Error", str(exc))
         else :
@@ -91,7 +91,7 @@ class subselect :
             self.show_message("Download failed", "Please select a subtitle")
         else :
             selected_subtitle = self.subtitles_in_list[i[0]]
-            download_subtitles([selected_subtitle], provider_configs=self.providers_auth)
+            download_subtitles([selected_subtitle], provider_configs=providers_auth)
             self.save_subtitle(self.video, True, selected_subtitle)
     
     def save_subtitle(self, video, change_filename, subtitle) :
@@ -112,10 +112,12 @@ class subselect :
 
 videotitle = save_dir = ""
 sub_language = "eng"
+providers_auth = {}
 
 if len(sys.argv) > 1 :
     videotitle = sys.argv[1]
     save_dir = sys.argv[2]
     sub_language = sys.argv[3]
+    providers_auth = json.loads(sys.argv[4])
     
 subselect().root.mainloop()


### PR DESCRIPTION
Portable Configuration
- Changes made to allow usage of script with portable python (and mpv).

To create a working portable python package follow these links.
- https://github.com/indygreg/python-build-standalone/
Install subliminal in the package using:
- python -m pip install subliminal
Add python location to subselect.conf as python= 
Path can be relative from the mpv directory or absolute.
For ex.
- python=python\\python
This is for windows where python binaries are located under root directory.
Directory structure for the above ex. is mpv_portable\python\python.exe

Note: I basically made this for myself to keep a portable mpv installation along with working subselect without having to install python and co. Just putting it here in case it seems useful at all to anyone.