### PR TITLE
Restore playback speed only if speed transition is enabled

### DIFF
--- a/speed-transition.lua
+++ b/speed-transition.lua
@@ -503,7 +503,9 @@ function switch_mode()
 end
 
 function reset_on_file_load()
-	restore_normalspeed()
+	if enable then
+		restore_normalspeed()
+	end
 	reset_state()
 end
 


### PR DESCRIPTION
Otherwise, it will reset the playback speed every time the file loaded, and for every file in the playlist